### PR TITLE
fixes #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # P2000.cas is auto-generated when starting M2000 without specifying a tape file
 /*.cas
 /*.bat
+/*.bmp
+/*.bin
 /m2000
 /m2000.exe
 /CWSDPMI.SWP

--- a/src/allegro.c
+++ b/src/allegro.c
@@ -59,6 +59,7 @@ ALLEGRO_BITMAP *FontBuf = NULL;
 ALLEGRO_BITMAP *FontBuf_bk = NULL;
 ALLEGRO_BITMAP *FontBuf_scaled = NULL;
 ALLEGRO_BITMAP *FontBuf_bk_scaled = NULL;
+ALLEGRO_BITMAP *ScreenshotBuf = NULL;
 
 //byte *DisplayBuf;               /* Screen buffer                            */
 
@@ -165,6 +166,7 @@ void TrashMachine(void)
   if (FontBuf_bk) al_destroy_bitmap(FontBuf_bk);
   if (FontBuf_scaled) al_destroy_bitmap(FontBuf_scaled);
   if (FontBuf_bk_scaled) al_destroy_bitmap(FontBuf_bk_scaled);
+  if (ScreenshotBuf) al_destroy_bitmap(ScreenshotBuf);
   if (OldCharacter) free (OldCharacter);
   //if (CharacterCache) free (CharacterCache);
 }
@@ -653,7 +655,10 @@ void Keyboard(void)
   {
     while (al_key_down(&kbdstate, ALLEGRO_KEY_F7))
       al_get_keyboard_state(&kbdstate);
-    al_save_bitmap(szBitmapFile, al_get_target_bitmap());
+
+    if (ScreenshotBuf) al_destroy_bitmap(ScreenshotBuf); //clean up previous screenshot
+    ScreenshotBuf = al_clone_bitmap(al_get_target_bitmap());
+    al_save_bitmap(szBitmapFile, ScreenshotBuf);
     NextBitmapFile();
   }
 


### PR DESCRIPTION
Allegro needs a dedicated image buffer for screenshots, because it starts a separate thread for saving the bitmap.