### PR TITLE
Windows compilation using CMake / Ubuntu WSL including Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: build
+
+on:
+  push:
+    branches: [ "*" ]
+
+jobs:
+  build-m2000-windows:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y mingw-w64 build-essential cmake zip curl
+    - name: Configure CMake
+      run: mkdir build && cd build && cmake ../src
+    - name: Build
+      run: cd build && make -j
+    - name: Upload launcher
+      uses: actions/upload-artifact@v3
+      with:
+        name: m2000win.zip
+        path: build/m2000win.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y mingw-w64 build-essential cmake zip curl
+      run: sudo apt-get update && sudo apt-get install -y mingw-w64 build-essential cmake zip curl tar
+    - uses: actions/checkout@v3
     - name: Configure CMake
       run: mkdir build && cd build && cmake ../src
     - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /m2000win.exe
 /CWSDPMI.SWP
 /djgpp/*
+build/*

--- a/README.md
+++ b/README.md
@@ -173,6 +173,30 @@ Note: when distributing m2000.exe, don't forget to include these Allegro 5 libra
   * allegro_image-5.*.dll
   * allegro_audio-5.*.dll
 
+### Windows (WSL Ubuntu cross-compilation)
+
+* Ensure you have [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install) installed 
+  and have downloaded the latest Ubuntu image from the Windows store.
+* Install the required following packages in Ubuntu
+
+```bash
+sudo apt install mingw-w64 build-essential cmake zip curl
+```
+
+* Clone this repository, create a `build` folder in its root directory, go to the `build` folder and compile
+  a Makefile using `cmake`
+
+```bash
+mkdir build && cd build && cmake ../src
+```
+
+* Compile the program by running
+
+```bash
+make -j
+```
+
+* You are done.
 
 ## More information on the P2000
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,84 @@
+# set minimum cmake requirements
+cmake_minimum_required(VERSION 3.18)
+
+set(CMAKE_C_COMPILER "x86_64-w64-mingw32-gcc")
+set(CMAKE_CXX_COMPILER "x86_64-w64-mingw32-g++")
+project(m2000win)
+
+# add custom directory to look for .cmake files
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules )
+
+# set specific cflags
+set(CMAKE_C_FLAGS "-Wall -fomit-frame-pointer -O2 -DLSB_FIRST -DHAVE_FTRUNCATE -DALLEGRO -DMSDOS")
+
+# set linking flags
+set(CMAKE_STATIC_LINKER_FLAGS "-s")
+
+# Enable release build
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# ensure Allegro 5 binaries for Windows are downloaded
+include(FetchContent)
+FetchContent_Declare(
+  allegro5
+  #URL https://github.com/liballeg/allegro5/releases/download/5.2.8.0/allegro-x86_64-w64-mingw32-gcc-12.1.0-posix-seh-dynamic-5.2.8.0.zip
+  #URL_HASH MD5=53ee801345c191eed5de01b2b9554475
+  URL https://github.com/liballeg/allegro5/releases/download/5.2.8.0/allegro-x86_64-w64-mingw32-gcc-12.1.0-posix-seh-static-5.2.8.0.zip
+  URL_HASH MD5=d671903c6d3af3dfccd63f79f7508f80
+)
+FetchContent_MakeAvailable(allegro5)
+FetchContent_GetProperties(allegro5)
+
+# Set include folders
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}
+                    ${CMAKE_BINARY_DIR}
+                    ${CMAKE_CURRENT_SOURCE_DIR}
+                    ${allegro5_SOURCE_DIR}/include)
+
+# Add sources
+set(SOURCES M2000.c P2000.c Z80.c Z80Debug.c Unix.c allegro.c)
+add_executable(m2000win ${SOURCES})
+
+# link libraries
+target_link_libraries(
+    m2000win 
+    -L${allegro5_SOURCE_DIR}/lib 
+    -lallegro
+    -lallegro_primitives
+    -lallegro_image
+    -lallegro_audio
+)
+
+# copy all dependencies to build a self-contained zip file 
+set(DEPDLL allegro allegro_primitives allegro_image allegro_audio)
+FOREACH(FDLL ${DEPDLL})
+    file(COPY ${allegro5_SOURCE_DIR}/bin/${FDLL}-5.2.dll DESTINATION ${CMAKE_BINARY_DIR})
+ENDFOREACH()
+
+set(SUPPORTFILES Default.fnt P2000ROM.bin BASIC.bin)
+FOREACH(SFILE ${SUPPORTFILES})
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../${SFILE} DESTINATION ${CMAKE_BINARY_DIR})
+ENDFOREACH()
+
+file(ARCHIVE_CREATE
+    OUTPUT "m2000win.zip"
+    PATHS 
+        "${CMAKE_BINARY_DIR}/m2000win.exe"
+        "${CMAKE_BINARY_DIR}/Default.fnt"
+        "${CMAKE_BINARY_DIR}/P2000ROM.bin"
+        "${CMAKE_BINARY_DIR}/BASIC.bin"
+        "${CMAKE_BINARY_DIR}/allegro-5.2.dll"
+        "${CMAKE_BINARY_DIR}/allegro_primitives-5.2.dll"
+        "${CMAKE_BINARY_DIR}/allegro_image-5.2.dll"
+        "${CMAKE_BINARY_DIR}/allegro_audio-5.2.dll"
+    FORMAT "zip")
+
+###
+# Installing
+##
+install (TARGETS m2000win DESTINATION bin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
                     ${allegro5_SOURCE_DIR}/include)
 
 # Add sources
-set(SOURCES M2000.c P2000.c Z80.c Z80Debug.c Unix.c allegro.c)
+set(SOURCES M2000.c P2000.c Z80.c Z80Debug.c unix.c allegro.c)
 add_executable(m2000win ${SOURCES})
 
 # link libraries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,9 +55,9 @@ target_link_libraries(
 )
 
 # copy all dependencies to build a self-contained zip file 
-set(DEPDLL allegro allegro_primitives allegro_image allegro_audio)
+set(DEPDLL allegro-5.2.dll allegro_primitives-5.2.dll allegro_image-5.2.dll allegro_audio-5.2.dll)
 FOREACH(FDLL ${DEPDLL})
-    file(COPY ${allegro5_SOURCE_DIR}/bin/${FDLL}-5.2.dll DESTINATION ${CMAKE_BINARY_DIR})
+    file(COPY ${allegro5_SOURCE_DIR}/bin/${FDLL} DESTINATION ${CMAKE_BINARY_DIR})
 ENDFOREACH()
 
 set(SUPPORTFILES Default.fnt P2000ROM.bin BASIC.bin)
@@ -65,20 +65,11 @@ FOREACH(SFILE ${SUPPORTFILES})
     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../${SFILE} DESTINATION ${CMAKE_BINARY_DIR})
 ENDFOREACH()
 
-file(ARCHIVE_CREATE
-    OUTPUT "m2000win.zip"
-    PATHS 
-        "${CMAKE_BINARY_DIR}/m2000win.exe"
-        "${CMAKE_BINARY_DIR}/Default.fnt"
-        "${CMAKE_BINARY_DIR}/P2000ROM.bin"
-        "${CMAKE_BINARY_DIR}/BASIC.bin"
-        "${CMAKE_BINARY_DIR}/allegro-5.2.dll"
-        "${CMAKE_BINARY_DIR}/allegro_primitives-5.2.dll"
-        "${CMAKE_BINARY_DIR}/allegro_image-5.2.dll"
-        "${CMAKE_BINARY_DIR}/allegro_audio-5.2.dll"
-    FORMAT "zip")
-
-###
-# Installing
-##
-install (TARGETS m2000win DESTINATION bin)
+# create a zip archive for deployment
+add_custom_command(
+    TARGET m2000win
+    COMMAND ${CMAKE_COMMAND} -E tar cvf m2000win.zip --format=zip -- m2000win.exe ${DEPDLL} ${SUPPORTFILES}
+    DEPENDS ${CMAKE_BINARY_DIR}/m2000win.exe
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    VERBATIM
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,25 @@
+ #*************************************************************************
+ #   CMakeLists.txt  --  This file is part of M2000.                      *
+ #                                                                        *
+ #   Author: Ivo Filot <i.a.w.filot@tue.nl>                               *
+ #                                                                        *
+ #   M2000 is a P2000T emulator originally designed by Marcel de Kogel    *
+ #                                                                        *
+ #   This file is free software: you can redistribute it and/or modify    *
+ #   it under the terms of the GNU General Public License as published    *
+ #   by the Free Software Foundation, either version 3 of the License,    *
+ #   or (at your option) any later version.                               *
+ #                                                                        *
+ #   This file is distributed in the hope that it will be useful,         *
+ #   but WITHOUT ANY WARRANTY; without even the implied warranty          *
+ #   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.              *
+ #   See the GNU General Public License for more details.                 *
+ #                                                                        *
+ #   You should have received a copy of the GNU General Public License    *
+ #   along with this program.  If not, see http://www.gnu.org/licenses/.  *
+ #                                                                        *
+ #*************************************************************************/
+
 # set minimum cmake requirements
 cmake_minimum_required(VERSION 3.18)
 
@@ -10,9 +32,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules )
 
 # set specific cflags
 set(CMAKE_C_FLAGS "-Wall -fomit-frame-pointer -O2 -DLSB_FIRST -DHAVE_FTRUNCATE -DALLEGRO -DMSDOS")
-
-# set linking flags
-set(CMAKE_STATIC_LINKER_FLAGS "-s")
 
 # Enable release build
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,8 +26,6 @@ endif()
 include(FetchContent)
 FetchContent_Declare(
   allegro5
-  #URL https://github.com/liballeg/allegro5/releases/download/5.2.8.0/allegro-x86_64-w64-mingw32-gcc-12.1.0-posix-seh-dynamic-5.2.8.0.zip
-  #URL_HASH MD5=53ee801345c191eed5de01b2b9554475
   URL https://github.com/liballeg/allegro5/releases/download/5.2.8.0/allegro-x86_64-w64-mingw32-gcc-12.1.0-posix-seh-static-5.2.8.0.zip
   URL_HASH MD5=d671903c6d3af3dfccd63f79f7508f80
 )

--- a/src/allegro.c
+++ b/src/allegro.c
@@ -10,6 +10,8 @@
 /***     Please, notify me, if you make any changes to this file          ***/
 /****************************************************************************/
 
+#define ALLEGRO_STATICLINK
+
 #include "P2000.h"
 #include "Unix.h"
 #include "Utils.h"


### PR DESCRIPTION
# Purpose
This pull requests aims to produce a robust compilation environment for the Windows (64 bit) executable of the M2000 emulator. It is designed around a cross-compilation procedure in a Ubuntu environment using the mingw compiler. For development purposes, this build procedure can be readily executed in a WSL Ubuntu image **on Windows**.

# Features
* Implemented a CMake-based build procedure wherein CMake automatically downloads the required Allegro5 dependencies (hardcoded to a specific version and verified using an MD5-checksum, which is to the best knowledge of this author considered best practice).
* Produce an all-in-one file for easy modification of compilation instructions (`CMakeLists.txt`).
* Production of a single `.zip` archive containing the executable, source files and dynamic libraries.
* Integration of build procedure into Github Actions for automatic development and deployment. The `.zip` is stored in Github Actions as an artifact. The repository maintainer can decide if this archive requires further deployment (e.g. to a website or to a release).

# Documentation
* The `README.md` has been adjusted to add, besides the experimental build procedure for Windows, a build procedure based on CMake.