### PR TITLE
fix #10 - default window now 960x720 (4:3 TV ratio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ ESC/F10      -  Quit emulator
                        slow
 -t / -m                Select P2000 model [-t]
 -video <mode>          Select video mode/window size [0]
-                       0 - 500x300 (Unix/X)
-                           320x240 (Linux/SVGALib, T-model emulation only)
+                       0 - 960x720 (Windows) [pixel perfect]
+                           500x300 (Unix/X)
                            256x240 (MS-DOS, T-model emulation only)
-                       1 - 520x490 (Unix/X)
-                           640x480 (Linux/SVGALib and MS-DOS)
+                       1 - 960x720 (Windows) [fat font]
+                           520x490 (Unix/X)
+                           640x480 (MS-DOS)
 -printer <filename>    Select file for printer output
                        Default is PRN for the MS-DOS version, stdout for
                        the Unix versions

--- a/src/Help.h
+++ b/src/Help.h
@@ -31,10 +31,14 @@ char *HelpText[] =
   "  -t / -m                    - Select P2000 model [-t]",
 #if defined(MSDOS) || defined(LINUX_SVGA)
   "  -video <mode>              - Select video mode (T-model emulation only) [0]",
+#ifdef ALLEGRO
+  "                               0 - 960x720 (pixel perfect) 1 - 960x720 (bold)",
+#else
 #ifdef MSDOS
   "                               0 - 256x240   1 - 640x480",
 #else
   "                               0 - 320x240   1 - 640x480",
+#endif
 #endif
 #else
   "  -video <mode>              - Select window size [0]",


### PR DESCRIPTION
Windows version now displays as 960x720, conform 4:3 TVs. 
Display mode 0 (default) is pixel perfect.
Display mode 1 uses a "fat font".
