### PR TITLE
Adding support for snapshot-generation for Windows 32bit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "*" ]
 
 jobs:
-  build-m2000-windows:
+  build-m2000-windows-64bit:
 
     runs-on: ubuntu-latest
 
@@ -19,7 +19,38 @@ jobs:
       run: cd build && make -j
     - name: Generate artifact name
       id: generate-name
-      run: echo "artifact_name=M2000-snapshot-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+      run: echo "artifact_name=M2000-snapshot-$(date +'%Y%m%d%H%M%S')-win64" >> $GITHUB_OUTPUT
+    - name: Upload launcher
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.generate-name.outputs.artifact_name }}
+        path: |
+          build/M2000.exe
+          build/allegro-5.2.dll
+          build/allegro_primitives-5.2.dll
+          build/allegro_image-5.2.dll
+          build/allegro_audio-5.2.dll
+          build/allegro_dialog-5.2.dll
+          build/allegro_memfile-5.2.dll
+          build/Default.fnt
+          build/P2000ROM.bin
+          build/BASIC.bin
+
+  build-m2000-windows-32bit:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y mingw-w64 build-essential cmake zip curl tar binutils-x86-64-linux-gnux32
+    - uses: actions/checkout@v3
+    - name: Configure CMake
+      run: mkdir build && cd build && cmake ../src -DUSE_WIN32=1
+    - name: Build
+      run: cd build && make -j
+    - name: Generate artifact name
+      id: generate-name
+      run: echo "artifact_name=M2000-snapshot-$(date +'%Y%m%d%H%M%S')-win32" >> $GITHUB_OUTPUT
     - name: Upload launcher
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install -y mingw-w64 build-essential cmake zip curl tar binutils-x86-64-linux-gnux32
+      run: sudo apt-get update && sudo apt-get install -y mingw-w64 build-essential cmake zip curl tar
     - uses: actions/checkout@v3
     - name: Configure CMake
       run: mkdir build && cd build && cmake ../src -DUSE_WIN32=1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,8 +27,13 @@ if(${CMAKE_VERSION} VERSION_GREATER "3.24.0")
     cmake_policy(SET CMP0135 NEW) # update timestamps of Allegro5 to moment of extraction
 endif()
 
-set(CMAKE_C_COMPILER "x86_64-w64-mingw32-gcc")
-set(CMAKE_CXX_COMPILER "x86_64-w64-mingw32-g++")
+if(USE_WIN32)
+    set(CMAKE_C_COMPILER "i686-w64-mingw32-gcc")
+    set(CMAKE_CXX_COMPILER "i686-w64-mingw32-g++")
+else()
+    set(CMAKE_C_COMPILER "x86_64-w64-mingw32-gcc")
+    set(CMAKE_CXX_COMPILER "x86_64-w64-mingw32-g++")
+endif()
 project(M2000)
 
 # add custom directory to look for .cmake files
@@ -48,11 +53,21 @@ endif()
 
 # ensure Allegro 5 binaries for Windows are downloaded
 include(FetchContent)
+
+if(USE_WIN32)
+FetchContent_Declare(
+  allegro5
+  URL https://github.com/liballeg/allegro5/releases/download/5.2.8.0/allegro-i686-w64-mingw32-gcc-12.1.0-posix-dwarf-static-5.2.8.0.zip
+  URL_HASH MD5=119474cd3b3484e0a9d0ce446e7a64d2
+)
+else()
 FetchContent_Declare(
   allegro5
   URL https://github.com/liballeg/allegro5/releases/download/5.2.8.0/allegro-x86_64-w64-mingw32-gcc-12.1.0-posix-seh-static-5.2.8.0.zip
   URL_HASH MD5=d671903c6d3af3dfccd63f79f7508f80
 )
+endif()
+
 FetchContent_MakeAvailable(allegro5)
 FetchContent_GetProperties(allegro5)
 
@@ -65,6 +80,11 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}
 # Add sources
 set(SOURCES M2000.c P2000.c Z80.c Z80Debug.c Allegro.c)
 add_executable(M2000 ${SOURCES})
+
+if(USE_WIN32)
+    message(STATUS "Setting compilation for 32 bit")
+    set_target_properties(M2000 PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
+endif()
 
 # link libraries
 target_link_libraries(


### PR DESCRIPTION
# Purpose
Adding support for auto-compilation of Windows 32 bit binaries using Github Actions

# Changes
* Added a `-USE_WIN32=1` tag for `CMake` to select whether to build 32 or 64 bit executables
* Modified `CMakelists.txt` to automatically download and package either the 32 or 64 bit Allegro5 dependencies (including checksum validation)
* Adjusted the `build.yml` file to generate both types of executables

# Note
I do not have a 32 bit Windows at my disposal. I have verified that the 32 bit executables have the correct signature (e.g. `PE32 executable`). Explicit validation on a native 32 bit system is warmly recommended.