### PR TITLE
"Open With" now shows "M2000 - Philips P2000 Emator"

### DIFF
--- a/package/WiX/product.wxs
+++ b/package/WiX/product.wxs
@@ -52,10 +52,17 @@
                   <RegistryValue Root="HKLM" Key="SOFTWARE\M2000\Capabilities" Name="ApplicationDescription" Value="M2000 - Philips P2000 Emulator" Type="string" />
                   <RegistryValue Root="HKLM" Key="SOFTWARE\M2000\Capabilities" Name="ApplicationName" Value="M2000" Type="string" />
                   <RegistryValue Root="HKLM" Key="SOFTWARE\M2000\Capabilities\FileAssociations" Name=".cas" Value="M2000.Cassette" Type="string" />
+                  <RegistryValue Root="HKLM" Key="SOFTWARE\M2000\Capabilities\FileAssociations" Name=".p2000t" Value="M2000.Cassette" Type="string" />
                   <RegistryValue Root="HKLM" Key="SOFTWARE\RegisteredApplications" Name="M2000" Value="SOFTWARE\M2000\Capabilities" Type="string" />
+                  <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\Applications\M2000.exe\SupportedTypes" Name=".cas" Value="" Type="string" />
+                  <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\Applications\M2000.exe\SupportedTypes" Name=".p2000t" Value="" Type="string" />
+                  <RegistryValue Root="HKLM" Key="SOFTWARE\Classes\Applications\M2000.exe\shell\open" Name="FriendlyAppName" Value="M2000 - Philips P2000 Emulator" Type="string" />
                   <ProgId Id="M2000.Cassette" Description="M2000 Cassette" Icon="cassette.ico">
                      <Extension Id="cas">
-                        <Verb Id="open" Command="Open" TargetFile="M2000.exe" Argument='"%1"' />
+                        <Verb Id="open_cas" Command="Open" TargetFile="M2000.exe" Argument='"%1"' />
+                     </Extension>
+                     <Extension Id="p2000t">
+                        <Verb Id="open_p2000t" Command="Open" TargetFile="M2000.exe" Argument='"%1"' />
                      </Extension>
                   </ProgId>
                </Component>

--- a/src/P2000.c
+++ b/src/P2000.c
@@ -371,14 +371,14 @@ void InsertCassette(const char *filename, FILE *f, int readOnly)
   TapeName=_TapeName;
 
   char *dot = strrchr(TapeName, '.');
-  if (!dot || strcasecmp(dot, ".cas") == 0) {
-    // .cas files use 256-byte header
-    TapeHeaderSize = TAPE_256_BYTE_HEADER_SIZE;
-    TapeHeaderOffset = TAPE_256_BYTE_HEADER_OFFSET;
-  } else {
-    // assume alternative cassette format with cleaned, 32-byte header
+  if (dot && strcasecmp(dot, ".p2000t") == 0) {
+    // .p2000t format uses 32-byte headers
     TapeHeaderSize = TAPE_32_BYTE_HEADER_SIZE;
     TapeHeaderOffset = TAPE_32_BYTE_HEADER_OFFSET;
+  } else {
+    // .cas (default) format uses 256-byte headers (of which 224 are unused)
+    TapeHeaderSize = TAPE_256_BYTE_HEADER_SIZE;
+    TapeHeaderOffset = TAPE_256_BYTE_HEADER_OFFSET;
   }
 
   if (TapeStream) fclose (TapeStream); //close previous stream


### PR DESCRIPTION
On Windows, selecting "Open With" now shows "M2000 - Philips P2000 Emulator" instead of "M2000.exe"